### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kiakiraki/curriculum-vitae/security/code-scanning/1](https://github.com/kiakiraki/curriculum-vitae/security/code-scanning/1)

To address this issue, we should add a `permissions` block that restricts the GITHUB_TOKEN to the least privilege necessary. For this workflow, which only checks out code and builds/checks/installs dependencies, only read access to repository contents is required. We can add `permissions: contents: read` either at the workflow (root) level or for the specific job. Best practice is to do so at the workflow root unless specific jobs require exceptions. Specifically, add the following near the top, after the `name` of the workflow and before the `on` trigger:  
```yaml
permissions:
  contents: read
```
No further changes (such as imports) are required, and this will not alter existing functionality. Existing steps (checkout, install, build, lint) will still work as they only need read access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
