### PR TITLE
Remove Findy link and rename Mixi department

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,13 +46,6 @@ import '../styles/resume.css'
             >
           </div>
           <div class="info-item">
-            <strong>Findy</strong>
-            <a
-              href="https://findy-code.io/share_profiles/tp8hu8kHODzvM"
-              target="_blank">findy-code.io/share_profiles/tp8hu8kHODzvM</a
-            >
-          </div>
-          <div class="info-item">
             <strong>GitHub</strong>
             <a href="https://github.com/kiakiraki" target="_blank">kiakiraki</a>
           </div>
@@ -99,7 +92,9 @@ import '../styles/resume.css'
             <div class="period">2021/03〜</div>
             <div class="company">株式会社MIXI</div>
             <ul class="career-details">
-              <li>みてね事業部 機械学習エンジニア / バックエンドエンジニア</li>
+              <li>
+                みてね事業本部 機械学習エンジニア / バックエンドエンジニア
+              </li>
             </ul>
           </div>
           <div class="career-item">


### PR DESCRIPTION
## Summary
- remove Findy profile link from basic info section
- rename MIXI work history from みてね事業部 to みてね事業本部

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68bfc369c3ec832a8ff9b80053f08a5d