### PR TITLE
Improve PDF layout mode UX to avoid confusion with theme toggle

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,6 +76,10 @@ const cvData = yaml.load(yamlContent) as CVData
       </button>
     </div>
 
+    <div id="pdf-indicator" class="pdf-indicator" role="status">
+      📄 PDFレイアウト表示中
+    </div>
+
     <main class="container">
       <header class="header">
         <h1>Curriculum-Vitae</h1>
@@ -226,6 +230,7 @@ const cvData = yaml.load(yamlContent) as CVData
             body.removeAttribute('data-layout')
           }
           setPdfButtonState(enabled)
+          themeBtn.disabled = enabled
         }
 
         // PDFレイアウトの復元

--- a/src/styles/resume.css
+++ b/src/styles/resume.css
@@ -145,9 +145,14 @@ a:hover {
   backdrop-filter: blur(8px);
 }
 
-.toggle-btn:hover {
+.toggle-btn:hover:not(:disabled) {
   background: var(--hover-color);
   transform: scale(1.05);
+}
+
+.toggle-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 #theme-btn {
@@ -165,6 +170,25 @@ a:hover {
   background: var(--accent-color);
   border-color: var(--accent-color);
   color: #ffffff;
+}
+
+.pdf-indicator {
+  display: none;
+  position: fixed;
+  top: 76px;
+  right: 20px;
+  z-index: 1000;
+  background: #ffffff;
+  border: 1px solid #d0d0d0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: #1e40af;
+}
+
+body[data-layout='pdf'] .pdf-indicator {
+  display: block;
 }
 
 .container {
@@ -437,17 +461,21 @@ body[data-layout='pdf'] {
   --text-color: #111111;
   --secondary-text: #333333;
   --border-color: #d0d0d0;
-  --accent-color: #111111;
-  --link-color: #111111;
-  --link-hover-color: #111111;
+  --accent-color: #1e40af;
+  --link-color: #0e7490;
+  --link-hover-color: #0e7490;
   --hover-color: #ffffff;
   --section-bg: #ffffff;
   --tag-bg: #f2f2f2;
-  --tag-text: #111111;
+  --tag-text: #1e40af;
   --orb-opacity: 0;
   --dot-grid-opacity: 0;
   background: var(--bg-color);
   color: var(--text-color);
+}
+
+body[data-layout='pdf'] a {
+  text-decoration: underline;
 }
 
 body[data-layout='pdf'] .container {
@@ -541,6 +569,11 @@ body[data-layout='pdf'] .oss-contributions .contribution-block {
     width: 40px;
     font-size: 18px;
   }
+
+  .pdf-indicator {
+    top: 63px;
+    right: 15px;
+  }
 }
 
 .network-diagram {
@@ -610,24 +643,33 @@ body[data-layout='pdf'] .oss-contributions .contribution-block {
     display: none;
   }
 
+  .pdf-indicator,
+  body[data-layout='pdf'] .pdf-indicator {
+    display: none;
+  }
+
   body {
     --bg-color: #ffffff;
     --text-color: #111111;
     --secondary-text: #333333;
     --border-color: #d0d0d0;
-    --accent-color: #111111;
-    --link-color: #111111;
-    --link-hover-color: #111111;
+    --accent-color: #1e40af;
+    --link-color: #0e7490;
+    --link-hover-color: #0e7490;
     --hover-color: #ffffff;
     --section-bg: #ffffff;
     --tag-bg: #f2f2f2;
-    --tag-text: #111111;
+    --tag-text: #1e40af;
     --orb-opacity: 0;
     --dot-grid-opacity: 0;
     background: #ffffff;
     color: #111111;
     font-size: 11pt;
     line-height: 1.45;
+  }
+
+  a {
+    text-decoration: underline;
   }
 
   .orb-purple {


### PR DESCRIPTION
## 概要

PDFレイアウトモード切替時に「ダークモード切替が動作した」と誤認される問題のUX改善です。

ダークモード中にPDFボタンを押すと画面が白基調に一変する一方、レイアウト変化は色に比べて地味なため、テーマ切替と区別がつきませんでした（機能自体は正常動作を確認済み）。PDFモードは「PDF変換・紙への印刷を前提とした白背景モード」という仕様は維持したまま、モードの状態を明示するようにしました。

## 変更内容

- **PDFモード中インジケーター**: トグルボタン直下に「📄 PDFレイアウト表示中」のピル型ラベルを固定表示。モバイル幅対応、印刷時は非表示
- **テーマボタンの無効化**: PDFモード中は `disabled` + グレーアウト（opacity 0.4）にして、テーマとは独立したモードであることを明確化
- **印刷向けアクセントカラー**: 完全モノクロだったPDFパレットに、見出し・タグは濃紺（#1e40af）、リンクは濃シアン（#0e7490）＋下線を追加。モノクロ印刷でも濃度差で判読可能
- **印刷時の写り込み防止**: `beforeprint` でPDFレイアウトが強制された際、詳細度の問題でインジケーターが印刷物に出てしまうバグを修正（`@media print` 内に同詳細度のセレクタを追加）
- **印刷パレットの統一**: `@media print` 内の変数も同じアクセントカラーに揃え、画面のPDFモードと印刷・PDF変換結果の見た目を一致させた

## 検証

ヘッドレスChromium（Playwright）で以下を確認:

- PDFモードON/OFFで `data-theme` / `data-theme-mode` / localStorage の `theme-mode` が変化しないこと
- PDFモード中にインジケーターが表示され、テーマボタンが無効化されること（クリック遮断も確認）
- 印刷メディアエミュレーションでインジケーターが非表示になること
- `page.pdf()` によるPDF生成が正常に動作すること
- `npm run lint` / `prettier --check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)